### PR TITLE
fix: Fix ped bugs related to hide/reveal and order

### DIFF
--- a/src/main/java/seedu/finclient/logic/Messages.java
+++ b/src/main/java/seedu/finclient/logic/Messages.java
@@ -14,10 +14,12 @@ public class Messages {
 
     public static final String MESSAGE_UNKNOWN_COMMAND = "Unknown command";
     public static final String MESSAGE_INVALID_COMMAND_FORMAT = "Invalid command format! \n%1$s";
-    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid";
+    public static final String MESSAGE_INVALID_PERSON_DISPLAYED_INDEX = "The person index provided is invalid.";
     public static final String MESSAGE_PERSONS_LISTED_OVERVIEW = "%1$d persons listed!";
     public static final String MESSAGE_DUPLICATE_FIELDS =
                 "Multiple values specified for the following single-valued field(s): ";
+    public static final String MESSAGE_PERSON_NOT_FOUND =
+                "The person you are locating does not exist in the address book.";
 
     /**
      * Returns an error message indicating the duplicate prefixes.

--- a/src/main/java/seedu/finclient/logic/commands/HideCommand.java
+++ b/src/main/java/seedu/finclient/logic/commands/HideCommand.java
@@ -17,7 +17,7 @@ import seedu.finclient.model.person.Person;
 public class HideCommand extends Command {
     public static final String COMMAND_WORD = "hide";
 
-    public static final String MESSAGE_SUCCESS = "Hid the person's details";
+    public static final String MESSAGE_SUCCESS = "Hid details for the specified person(s).";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Hides details of person(s).\n"
             + "Parameters: all | INDEX | KEYWORD [MORE_KEYWORDS]...\n"
@@ -74,6 +74,11 @@ public class HideCommand extends Command {
             Person personToHide = lastShownList.get(targetIndex.getZeroBased());
             model.hidePerson(personToHide);
         } else {
+
+            if (!model.hasPerson(predicate)) {
+                throw new CommandException(Messages.MESSAGE_PERSON_NOT_FOUND);
+            }
+
             model.hidePerson(predicate);
         }
 

--- a/src/main/java/seedu/finclient/logic/commands/RevealCommand.java
+++ b/src/main/java/seedu/finclient/logic/commands/RevealCommand.java
@@ -17,7 +17,7 @@ import seedu.finclient.model.person.Person;
 public class RevealCommand extends Command {
     public static final String COMMAND_WORD = "reveal";
 
-    public static final String MESSAGE_SUCCESS = "Revealed the person's details";
+    public static final String MESSAGE_SUCCESS = "Revealed details for the specified person(s).";
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Reveals hidden details of person(s).\n"
             + "Parameters: all | INDEX | KEYWORD [MORE_KEYWORDS]...\n"
@@ -74,6 +74,11 @@ public class RevealCommand extends Command {
             Person personToReveal = lastShownList.get(targetIndex.getZeroBased());
             model.revealPerson(personToReveal);
         } else {
+
+            if (!model.hasPerson(predicate)) {
+                throw new CommandException(Messages.MESSAGE_PERSON_NOT_FOUND);
+            }
+
             model.revealPerson(predicate);
         }
 

--- a/src/main/java/seedu/finclient/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/finclient/logic/parser/EditCommandParser.java
@@ -49,7 +49,8 @@ public class EditCommandParser implements Parser<EditCommand> {
             throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommand.MESSAGE_USAGE), pe);
         }
 
-        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_EMAIL, PREFIX_ADDRESS);
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_NAME, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_REMARK,
+                PREFIX_COMPANY, PREFIX_JOB, PREFIX_PLATFORM, PREFIX_NETWORTH);
 
         EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
 

--- a/src/main/java/seedu/finclient/logic/parser/HideCommandParser.java
+++ b/src/main/java/seedu/finclient/logic/parser/HideCommandParser.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import seedu.finclient.commons.core.index.Index;
 import seedu.finclient.commons.util.StringUtil;
 import seedu.finclient.logic.commands.HideCommand;
+import seedu.finclient.logic.commands.RevealCommand;
 import seedu.finclient.logic.parser.exceptions.ParseException;
 import seedu.finclient.model.person.NameContainsKeywordsPredicate;
 
@@ -40,7 +41,14 @@ public class HideCommandParser implements Parser<HideCommand> {
             return new HideCommand(index);
         }
 
-        // 3) Otherwise, treat them as name keywords
+        // 3) Otherwise, ensure they contain only letters and treat as keywords
+        for (String arg : splitArgs) {
+            if (!arg.matches("[a-zA-Z]+")) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, RevealCommand.MESSAGE_USAGE));
+            }
+        }
+
         return new HideCommand(new NameContainsKeywordsPredicate(Arrays.asList(splitArgs)));
     }
 }

--- a/src/main/java/seedu/finclient/logic/parser/OrderCommandParser.java
+++ b/src/main/java/seedu/finclient/logic/parser/OrderCommandParser.java
@@ -1,5 +1,6 @@
 package seedu.finclient.logic.parser;
 
+import static seedu.finclient.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.finclient.logic.parser.CliSyntax.PREFIX_AMOUNT;
 import static seedu.finclient.logic.parser.CliSyntax.PREFIX_ORDER;
 import static seedu.finclient.logic.parser.CliSyntax.PREFIX_PRICE;
@@ -26,9 +27,11 @@ public class OrderCommandParser implements Parser<OrderCommand> {
 
         // parse the index from the preamble
         if (argMultimap.getPreamble().isEmpty()) {
-            throw new ParseException("Must provide an index! \n" + OrderCommand.MESSAGE_USAGE);
+            throw new ParseException(MESSAGE_INVALID_COMMAND_FORMAT + OrderCommand.MESSAGE_USAGE);
         }
         Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
+
+        argMultimap.verifyNoDuplicatePrefixesFor(PREFIX_ORDER, PREFIX_AMOUNT, PREFIX_PRICE);
 
         boolean hasOrder = argMultimap.getValue(PREFIX_ORDER).isPresent();
         boolean hasAmount = argMultimap.getValue(PREFIX_AMOUNT).isPresent();
@@ -47,7 +50,8 @@ public class OrderCommandParser implements Parser<OrderCommand> {
             order = new Order("NONE");
         } else {
             // partial: e.g. user gave order type but not amount? Throw error
-            throw new ParseException("If you specify an order, you must provide all of order, amount, price.");
+            throw new ParseException("If you specify an order, you must provide all of order, amount, price.\n"
+                    + OrderCommand.MESSAGE_USAGE);
         }
 
         return new OrderCommand(index, order);

--- a/src/main/java/seedu/finclient/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/finclient/logic/parser/ParserUtil.java
@@ -152,6 +152,9 @@ public class ParserUtil {
         String trimmedAmount = amount.trim();
         String trimmedPrice = price.trim();
 
+        // Remove leading zeros from price string
+        trimmedPrice = removeLeadingZeros(trimmedPrice);
+
         // 1) Parse the order type (BUY or SELL)
         Order.OrderType orderType;
         try {
@@ -178,6 +181,22 @@ public class ParserUtil {
         }
 
         return new Order(orderType, trimmedPrice, quantity);
+    }
+
+    private static String removeLeadingZeros(String price) {
+        if (price.contains(".")) {
+            // Split into integer and fractional parts
+            String[] parts = price.split("\\.", 2);
+            // Remove leading zeros from the integer part.
+            String integerPart = parts[0].replaceFirst("^0+(?!$)", "");
+            if (integerPart.isEmpty()) {
+                integerPart = "0";
+            }
+            return integerPart + "." + parts[1];
+        } else {
+            // No decimal point, simply remove leading zeros.
+            return price.replaceFirst("^0+(?!$)", "");
+        }
     }
 
     /**

--- a/src/main/java/seedu/finclient/logic/parser/RevealCommandParser.java
+++ b/src/main/java/seedu/finclient/logic/parser/RevealCommandParser.java
@@ -40,7 +40,14 @@ public class RevealCommandParser implements Parser<RevealCommand> {
             return new RevealCommand(index);
         }
 
-        // 3) Otherwise, treat them as name keywords
+        // 3) Otherwise, ensure they contain only letters and treat as keywords
+        for (String arg : splitArgs) {
+            if (!arg.matches("[a-zA-Z]+")) {
+                throw new ParseException(
+                        String.format(MESSAGE_INVALID_COMMAND_FORMAT, RevealCommand.MESSAGE_USAGE));
+            }
+        }
+
         return new RevealCommand(new NameContainsKeywordsPredicate(Arrays.asList(splitArgs)));
     }
 }

--- a/src/main/java/seedu/finclient/model/FinClient.java
+++ b/src/main/java/seedu/finclient/model/FinClient.java
@@ -70,6 +70,14 @@ public class FinClient implements ReadOnlyFinClient {
     }
 
     /**
+     * Returns true if a person that matches the given {@code predicate} exists in the address book.
+     */
+    public boolean hasPerson(Predicate<Person> predicate) {
+        requireNonNull(predicate);
+        return persons.contains(predicate);
+    }
+
+    /**
      * Adds a person to the address book.
      * The person must not already exist in the address book.
      */

--- a/src/main/java/seedu/finclient/model/Model.java
+++ b/src/main/java/seedu/finclient/model/Model.java
@@ -60,6 +60,11 @@ public interface Model {
     boolean hasPerson(Person person);
 
     /**
+     * Returns true if a person that matches the given {@code predicate} exists in the address book.
+     */
+    boolean hasPerson(Predicate<Person> predicate);
+
+    /**
      * Deletes the given person.
      * The person must exist in the address book.
      */

--- a/src/main/java/seedu/finclient/model/ModelManager.java
+++ b/src/main/java/seedu/finclient/model/ModelManager.java
@@ -96,6 +96,12 @@ public class ModelManager implements Model {
     }
 
     @Override
+    public boolean hasPerson(Predicate<Person> predicate) {
+        requireNonNull(predicate);
+        return finClient.hasPerson(predicate);
+    }
+
+    @Override
     public void deletePerson(Person target) {
         finClient.removePerson(target);
     }

--- a/src/main/java/seedu/finclient/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/finclient/model/person/UniquePersonList.java
@@ -43,6 +43,14 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Returns true if the list contains a person matching the given predicate.
+     */
+    public boolean contains(Predicate<Person> predicate) {
+        requireNonNull(predicate);
+        return internalList.stream().anyMatch(predicate);
+    }
+
+    /**
      * Adds a person to the list.
      * The person must not already exist in the list.
      */

--- a/src/test/java/seedu/finclient/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/finclient/logic/commands/AddCommandTest.java
@@ -141,6 +141,11 @@ public class AddCommandTest {
         }
 
         @Override
+        public boolean hasPerson(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");
         }

--- a/src/test/java/seedu/finclient/logic/commands/HideCommandTest.java
+++ b/src/test/java/seedu/finclient/logic/commands/HideCommandTest.java
@@ -79,6 +79,17 @@ public class HideCommandTest {
     }
 
     @Test
+    public void hideByName_noMatchingPerson_throwsCommandException() {
+        // Use a stub where hasPerson(predicate) returns false.
+        ModelStubHideByPredicateFalse modelStub = new ModelStubHideByPredicateFalse();
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("Nonexistent"));
+        HideCommand hideByPredicate = new HideCommand(predicate);
+
+        assertThrows(CommandException.class, Messages.MESSAGE_PERSON_NOT_FOUND, ()
+                -> hideByPredicate.execute(modelStub));
+    }
+
+    @Test
     public void equals() {
         HideCommand hideAll = new HideCommand();
         HideCommand hideAliceIndex = new HideCommand(Index.fromOneBased(1));
@@ -350,7 +361,7 @@ public class HideCommandTest {
     }
 
     /**
-     * A Model stub that records when hidePerson(Predicate) is called.
+     * A Model stub that records when hidePerson(Predicate) is called and returns true for hasPerson(predicate).
      */
     private static class ModelStubHideByPredicate implements Model {
         private Predicate<Person> predicateUsed = null;
@@ -457,6 +468,111 @@ public class HideCommandTest {
         @Override
         public void sortPersons(String criteria) {
             throw new AssertionError("This method should not be called.");
+        }
+    }
+
+    /**
+     * A Model stub where hasPerson(Predicate) returns false,
+     * simulating the case where no person matches the predicate.
+     */
+    private static class ModelStubHideByPredicateFalse implements Model {
+
+        // All other methods throw AssertionError as they are not expected to be called.
+        @Override
+        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public ReadOnlyUserPrefs getUserPrefs() {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public GuiSettings getGuiSettings() {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public Path getFinClientFilePath() {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void setFinClientFilePath(Path addressBookFilePath) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void addPerson(Person person) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void setFinClient(ReadOnlyFinClient newData) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public ReadOnlyFinClient getFinClient() {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public boolean hasPerson(Person person) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public boolean hasPerson(Predicate<Person> predicate) {
+            return false;
+        }
+        @Override
+        public void deletePerson(Person target) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void setPerson(Person target, Person editedPerson) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void hidePerson(Predicate<Person> predicate) {
+            throw new AssertionError("hidePerson(Predicate) should not be called when no person matches.");
+        }
+        @Override
+        public void hidePerson(Person person) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void revealPerson(Predicate<Person> predicate) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void revealPerson(Person person) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void hideAllPersons() {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void revealAllPersons() {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public Optional<Double> calculateClearingPrice() {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public List<Person> getUpcomingPersons(int count) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void sortPersons(String criteria) {
+            throw new AssertionError("Not expected to be called.");
         }
     }
 }

--- a/src/test/java/seedu/finclient/logic/commands/HideCommandTest.java
+++ b/src/test/java/seedu/finclient/logic/commands/HideCommandTest.java
@@ -173,6 +173,12 @@ public class HideCommandTest {
         public boolean hasPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public boolean hasPerson(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
         @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");
@@ -283,6 +289,12 @@ public class HideCommandTest {
         public boolean hasPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public boolean hasPerson(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
         @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");
@@ -384,6 +396,12 @@ public class HideCommandTest {
         public boolean hasPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public boolean hasPerson(Predicate<Person> predicate) {
+            return true; // Always returns true for the stub
+        }
+
         @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");

--- a/src/test/java/seedu/finclient/logic/commands/OrderCommandTest.java
+++ b/src/test/java/seedu/finclient/logic/commands/OrderCommandTest.java
@@ -185,6 +185,12 @@ public class OrderCommandTest {
         public boolean hasPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public boolean hasPerson(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
         @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");

--- a/src/test/java/seedu/finclient/logic/commands/RevealCommandTest.java
+++ b/src/test/java/seedu/finclient/logic/commands/RevealCommandTest.java
@@ -79,6 +79,17 @@ public class RevealCommandTest {
     }
 
     @Test
+    public void revealByName_noMatchingPerson_throwsCommandException() {
+        // Use a model stub where hasPerson(predicate) returns false.
+        ModelStubRevealByPredicateFalse modelStub = new ModelStubRevealByPredicateFalse();
+        NameContainsKeywordsPredicate predicate = new NameContainsKeywordsPredicate(Arrays.asList("Nonexistent"));
+        RevealCommand revealByPredicate = new RevealCommand(predicate);
+
+        assertThrows(CommandException.class, Messages.MESSAGE_PERSON_NOT_FOUND, ()
+                -> revealByPredicate.execute(modelStub));
+    }
+
+    @Test
     public void equals() {
         RevealCommand revealAll = new RevealCommand();
         RevealCommand revealAliceIndex = new RevealCommand(Index.fromOneBased(1));
@@ -460,6 +471,114 @@ public class RevealCommandTest {
         @Override
         public void sortPersons(String criteria) {
             throw new AssertionError("This method should not be called.");
+        }
+    }
+
+    /**
+     * A Model stub where hasPerson(Predicate) returns false,
+     * simulating the case where no person matches the predicate.
+     */
+    private static class ModelStubRevealByPredicateFalse implements Model {
+
+        @Override
+        public Optional<Double> calculateClearingPrice() {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public ReadOnlyUserPrefs getUserPrefs() {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public GuiSettings getGuiSettings() {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void setGuiSettings(GuiSettings guiSettings) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public Path getFinClientFilePath() {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void setFinClientFilePath(Path addressBookFilePath) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void addPerson(Person person) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void setFinClient(ReadOnlyFinClient newData) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public ReadOnlyFinClient getFinClient() {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public boolean hasPerson(Person person) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public boolean hasPerson(Predicate<Person> predicate) {
+            return false;
+        }
+        @Override
+        public void deletePerson(Person target) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void setPerson(Person target, Person editedPerson) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void hidePerson(Predicate<Person> predicate) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void hidePerson(Person person) {
+            throw new AssertionError("Not expected to be called.");
+        }
+
+        @Override
+        public void revealPerson(Predicate<Person> predicate) {
+            throw new AssertionError("revealPerson(Predicate) should not be called when no person matches.");
+        }
+
+        @Override
+        public void revealPerson(Person person) {
+            throw new AssertionError("Not expected to be called.");
+        }
+
+        @Override
+        public void hideAllPersons() {
+            throw new AssertionError("Not expected to be called.");
+        }
+
+        @Override
+        public void revealAllPersons() {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public ObservableList<Person> getFilteredPersonList() {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void updateFilteredPersonList(Predicate<Person> predicate) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public List<Person> getUpcomingPersons(int count) {
+            throw new AssertionError("Not expected to be called.");
+        }
+        @Override
+        public void sortPersons(String criteria) {
+            throw new AssertionError("Not expected to be called.");
         }
     }
 }

--- a/src/test/java/seedu/finclient/logic/commands/RevealCommandTest.java
+++ b/src/test/java/seedu/finclient/logic/commands/RevealCommandTest.java
@@ -181,6 +181,12 @@ public class RevealCommandTest {
         public boolean hasPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public boolean hasPerson(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
         @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");
@@ -286,6 +292,12 @@ public class RevealCommandTest {
         public boolean hasPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public boolean hasPerson(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
         @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");
@@ -387,6 +399,12 @@ public class RevealCommandTest {
         public boolean hasPerson(Person person) {
             throw new AssertionError("This method should not be called.");
         }
+
+        @Override
+        public boolean hasPerson(Predicate<Person> predicate) {
+            return true;
+        }
+
         @Override
         public void deletePerson(Person target) {
             throw new AssertionError("This method should not be called.");

--- a/src/test/java/seedu/finclient/logic/parser/HideCommandParserTest.java
+++ b/src/test/java/seedu/finclient/logic/parser/HideCommandParserTest.java
@@ -56,4 +56,19 @@ public class HideCommandParserTest {
         HideCommand expected2 = new HideCommand(new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
         assertEquals(expected2, command2);
     }
+
+    // 5) Invalid keyword: any token contains non-letter characters should throw ParseException.
+    @Test
+    public void parse_invalidKeywordContainingNonLetters_throwsParseException() {
+        // Single token containing non-letters (e.g., "Alice1")
+        assertThrows(ParseException.class, () -> parser.parse("Alice1"),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, HideCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_multipleKeywordsWithOneInvalidToken_throwsParseException() {
+        // Multiple tokens with one token containing non-letter characters (e.g., "Alice Bob!")
+        assertThrows(ParseException.class, () -> parser.parse("Alice Bob!"),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, HideCommand.MESSAGE_USAGE));
+    }
 }

--- a/src/test/java/seedu/finclient/logic/parser/ParserUtilTest.java
+++ b/src/test/java/seedu/finclient/logic/parser/ParserUtilTest.java
@@ -298,6 +298,22 @@ public class ParserUtilTest {
         assertEquals(5.00, order.getPrice(), 1e-9);
     }
 
+    // New tests to verify leading zeros in price are removed correctly
+    @Test
+    public void parseOrder_leadingZerosInPrice_returnsParsedPrice() throws Exception {
+        // Price with leading zeros before the integer part
+        Order order1 = parseOrder("BUY", "10", "0005.00");
+        assertEquals(Order.OrderType.BUY, order1.getOrderType());
+        assertEquals(10, order1.getQuantity());
+        assertEquals(5.00, order1.getPrice(), 1e-9);
+
+        // Price with leading zeros where the integer part is zero
+        Order order2 = parseOrder("SELL", "20", "000.50");
+        assertEquals(Order.OrderType.SELL, order2.getOrderType());
+        assertEquals(20, order2.getQuantity());
+        assertEquals(0.50, order2.getPrice(), 1e-9);
+    }
+
     @Test
     public void parseCompany_null_throwsNullPointerException() {
         assertThrows(NullPointerException.class, () -> ParserUtil.parseCompany((String) null));

--- a/src/test/java/seedu/finclient/logic/parser/RevealCommandParserTest.java
+++ b/src/test/java/seedu/finclient/logic/parser/RevealCommandParserTest.java
@@ -59,4 +59,19 @@ public class RevealCommandParserTest {
                 new NameContainsKeywordsPredicate(Arrays.asList("Alice", "Bob")));
         assertEquals(expected2, command2);
     }
+
+    // 5) Invalid keyword: any token contains non-letter characters should throw ParseException.
+    @Test
+    public void parse_invalidKeywordContainingNonLetters_throwsParseException() {
+        // Single token containing non-letters (e.g., "Alice1")
+        assertThrows(ParseException.class, () -> parser.parse("Alice1"),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RevealCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_multipleKeywordsWithOneInvalidToken_throwsParseException() {
+        // Multiple tokens with one token containing non-letter characters (e.g., "Alice Bob!")
+        assertThrows(ParseException.class, () -> parser.parse("Alice Bob!"),
+                String.format(MESSAGE_INVALID_COMMAND_FORMAT, RevealCommand.MESSAGE_USAGE));
+    }
 }

--- a/src/test/java/seedu/finclient/model/FinClientTest.java
+++ b/src/test/java/seedu/finclient/model/FinClientTest.java
@@ -56,7 +56,7 @@ public class FinClientTest {
 
     @Test
     public void hasPerson_nullPerson_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> finClient.hasPerson(null));
+        assertThrows(NullPointerException.class, () -> finClient.hasPerson((Person) null));
     }
 
     @Test

--- a/src/test/java/seedu/finclient/model/FinClientTest.java
+++ b/src/test/java/seedu/finclient/model/FinClientTest.java
@@ -13,6 +13,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
@@ -76,6 +77,38 @@ public class FinClientTest {
         Person editedAlice = new PersonBuilder(ALICE).withAddress(VALID_ADDRESS_BOB).withTags(VALID_TAG_HUSBAND)
                 .build();
         assertTrue(finClient.hasPerson(editedAlice));
+    }
+
+    // New tests for the predicate-based hasPerson method
+
+    @Test
+    public void hasPerson_nullPredicate_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> finClient.hasPerson((Predicate<Person>) null));
+    }
+
+    @Test
+    public void hasPersonPredicate_personNotInAddressBook_returnsFalse() {
+        Predicate<Person> predicate = person -> person.equals(ALICE);
+        assertFalse(finClient.hasPerson(predicate));
+    }
+
+    @Test
+    public void hasPersonPredicate_personInAddressBook_returnsTrue() {
+        finClient.addPerson(ALICE);
+        Predicate<Person> predicate = person -> person.equals(ALICE);
+        assertTrue(finClient.hasPerson(predicate));
+    }
+
+    @Test
+    public void hasPersonPredicate_personWithSameIdentityFieldsInAddressBook_returnsTrue() {
+        finClient.addPerson(ALICE);
+        Person editedAlice = new PersonBuilder(ALICE)
+                .withAddress(VALID_ADDRESS_BOB)
+                .withTags(VALID_TAG_HUSBAND)
+                .build();
+        // Using isSamePerson to check for identity equivalence
+        Predicate<Person> predicate = person -> person.isSamePerson(editedAlice);
+        assertTrue(finClient.hasPerson(predicate));
     }
 
     @Test

--- a/src/test/java/seedu/finclient/model/ModelManagerTest.java
+++ b/src/test/java/seedu/finclient/model/ModelManagerTest.java
@@ -11,6 +11,7 @@ import static seedu.finclient.testutil.TypicalPersons.BENSON;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Arrays;
+import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
@@ -87,6 +88,26 @@ public class ModelManagerTest {
     public void hasPerson_personInAddressBook_returnsTrue() {
         modelManager.addPerson(ALICE);
         assertTrue(modelManager.hasPerson(ALICE));
+    }
+
+    @Test
+    public void hasPersonPredicate_nullPredicate_throwsNullPointerException() {
+        assertThrows(NullPointerException.class, () -> modelManager.hasPerson((Predicate<Person>) null));
+    }
+
+    @Test
+    public void hasPersonPredicate_personNotInAddressBook_returnsFalse() {
+        // Predicate that checks if a person equals ALICE.
+        Predicate<Person> predicate = person -> person.equals(ALICE);
+        assertFalse(modelManager.hasPerson(predicate));
+    }
+
+    @Test
+    public void hasPersonPredicate_personInAddressBook_returnsTrue() {
+        modelManager.addPerson(ALICE);
+        // Predicate that checks if a person equals ALICE.
+        Predicate<Person> predicate = person -> person.equals(ALICE);
+        assertTrue(modelManager.hasPerson(predicate));
     }
 
     @Test

--- a/src/test/java/seedu/finclient/model/ModelManagerTest.java
+++ b/src/test/java/seedu/finclient/model/ModelManagerTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 import seedu.finclient.commons.core.GuiSettings;
 import seedu.finclient.model.person.NameContainsKeywordsPredicate;
+import seedu.finclient.model.person.Person;
 import seedu.finclient.testutil.FinClientBuilder;
 
 public class ModelManagerTest {
@@ -74,7 +75,7 @@ public class ModelManagerTest {
 
     @Test
     public void hasPerson_nullPerson_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> modelManager.hasPerson(null));
+        assertThrows(NullPointerException.class, () -> modelManager.hasPerson((Person) null));
     }
 
     @Test

--- a/src/test/java/seedu/finclient/model/person/UniquePersonListTest.java
+++ b/src/test/java/seedu/finclient/model/person/UniquePersonListTest.java
@@ -32,7 +32,7 @@ public class UniquePersonListTest {
 
     @Test
     public void contains_nullPerson_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> uniquePersonList.contains(null));
+        assertThrows(NullPointerException.class, () -> uniquePersonList.contains((Person) null));
     }
 
     @Test


### PR DESCRIPTION
- Add a model method to check if the person to hide/reveal exists
- Add a check in hide/reveal parser to ensure keywords only accept letters
- Modify success messages for hide/reveal to include multiple person scenario
- Align error messages of the order command
- Add a parsing method to remove leading zeros in order price
- Add a check in order parser to prevent duplicate parameters

fix #256 
fix #249 
fix #241 
fix #224 
fix #218 and fix #217
fix #213 
fix #204 

